### PR TITLE
Fix non unique knots for intersections

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OceanGrids"
 uuid = "cfe838f4-859f-11e9-2ea1-df7d4e7c3537"
 authors = ["Benoit Pasquier <briochemc@gmail.com>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -609,10 +609,12 @@ function intersections(x::AbstractArray{T}, y, ylevs) where T
 		mini_y = view(y, i:i+1)
 		idx = sortperm(mini_y)
 		a, b = view(mini_y, idx)
-		itp = LinearInterpolation(mini_y[idx], mini_x[idx], extrapolation_bc=Line())
-		for x_intersect in itp(ylevs[a .< ylevs .≤ b])
-			push!(out, x_intersect)
-		end
+        if a ≠ b
+		    itp = LinearInterpolation(mini_y[idx], mini_x[idx], extrapolation_bc=Line())
+		    for x_intersect in itp(ylevs[a .< ylevs .≤ b])
+		    	push!(out, x_intersect)
+		    end
+        end
 	end
 	return out
 end


### PR DESCRIPTION
Fixes the intersection function (broken with Interpolations v0.13.2, https://github.com/JuliaMath/Interpolations.jl/issues/420)

TODO: 
- [ ] Avoid interpolations here and compute the intersection by hand... 
- [ ] Add tests